### PR TITLE
Make it work on Debian, add TLS, option to compile opensips, and restrict listen-ng.

### DIFF
--- a/federated-sip.yml
+++ b/federated-sip.yml
@@ -111,14 +111,17 @@
 
     - name: Running make for opensip modules
       command: "{{ item }} chdir=/usr/local/src/opensips"
-      when: compile_opensips == 'true'
-      
+      when: compile_opensips == 'true'   
       environment:
         TLS: 1
         include_modules: "db_sqlite uri_radius rtpengine proto_tls tls_mgm signaling sl tm uri"
       with_items:
         - make modules
-        
+    
+    - name: Debian doesn't use /etc/sysconfig folder, symlink to /etc/default
+      when: ansible_facts['os_family'] == "Debian"
+      command: "ln -s /etc/default /etc/sysconfig"
+    
     - name: Running make install for opensips
       command: "make install chdir=/usr/local/src/opensips/"
       when: compile_opensips == 'true'

--- a/federated-sip.yml
+++ b/federated-sip.yml
@@ -8,18 +8,22 @@
 
     - name: install vim
       yum: name=vim-enhanced
+      when: ansible_facts['os_family'] == "RedHat"
 
     - name: install epel
       yum: name=epel-release
+      when: ansible_facts['os_family'] == "RedHat"
 
     - name: install opensips repo
       yum: name=http://yum.opensips.org/2.4/releases/el/7/x86_64/opensips-yum-releases-2.4-3.el7.noarch.rpm
+      when: ansible_facts['os_family'] == "RedHat"
 
     - group: name=opensips state=present
     - user: name=opensips createhome=no group=opensips
 
     - name: "Install required opensips packages"
       yum: state=present name={{ item }}
+      when: ansible_facts['os_family'] == "RedHat"
       with_items:
         - opensips
         - opensips-db_sqlite
@@ -31,6 +35,7 @@
 
     - name: install rtpengine deps
       yum: state=present name={{ item }}
+      when: ansible_facts['os_family'] == "RedHat"
       with_items:
         - git
         - gcc
@@ -65,6 +70,7 @@
 
     - name: install sqlite pcre extension deps
       yum: state=present name={{ item }}
+      when: ansible_facts['os_family'] == "RedHat"
       with_items:
         - sqlite
         - sqlite-devel
@@ -72,6 +78,7 @@
     - name: Stopping rtpengine
       service: name=rtpengine state=stopped
       when: firstrun == 'false'
+      
     - name: Stopping opensips
       service: name=opensips state=stopped
       when: firstrun == 'false'

--- a/federated-sip.yml
+++ b/federated-sip.yml
@@ -16,14 +16,14 @@
 
     - name: install opensips repo
       yum: name=http://yum.opensips.org/2.4/releases/el/7/x86_64/opensips-yum-releases-2.4-3.el7.noarch.rpm
-      when: ansible_facts['os_family'] == "RedHat"
+      when: ansible_facts['os_family'] == "RedHat" and compile_opensips == 'false'
 
     - group: name=opensips state=present
     - user: name=opensips createhome=no group=opensips
 
     - name: "Install required opensips packages"
       yum: state=present name={{ item }}
-      when: ansible_facts['os_family'] == "RedHat"
+      when: ansible_facts['os_family'] == "RedHat" and compile_opensips == 'false'
       with_items:
         - opensips
         - opensips-db_sqlite
@@ -88,6 +88,9 @@
        version=mr6.2.1
     - git: repo=https://github.com/ralight/sqlite3-pcre.git
        dest=/usr/local/src/sqlite3-pcre
+    - git: repo=https://github.com/OpenSIPS/opensips.git
+       dest=/usr/local/src/opensips
+       version=2.4.6 #v3.0.0 fails unless depreciated uri module is removed from config
 
     - name: Running make for rtpengine
       command: "{{ item }} chdir=/usr/local/src/rtpengine/daemon"
@@ -105,6 +108,20 @@
         - make
     - name: Running make install for sqlite3-pcre
       command: "make install chdir=/usr/local/src/sqlite3-pcre/"
+
+    - name: Running make for opensip modules
+      command: "{{ item }} chdir=/usr/local/src/opensips"
+      when: compile_opensips == 'true'
+      
+      environment:
+        TLS: 1
+        include_modules: "db_sqlite uri_radius rtpengine proto_tls tls_mgm signaling sl tm uri"
+      with_items:
+        - make modules
+        
+    - name: Running make install for opensips
+      command: "make install chdir=/usr/local/src/opensips/"
+      when: compile_opensips == 'true'
 
     - name: Copying opensips configuration
       template: src=templates/opensips.cfg.j2 dest=/etc/opensips/opensips.cfg

--- a/templates/opensips.cfg.j2
+++ b/templates/opensips.cfg.j2
@@ -163,7 +163,7 @@ modparam("stun","alternate_ip","127.0.0.1")
 modparam("stun","alternate_port","6050")
 
 # ----- rtpengine params ----
-modparam("rtpengine", "rtpengine_sock", "udp:{{ listen_ip }}:60000")
+modparam("rtpengine", "rtpengine_sock", "udp:127.0.0.1:60000")
 
 {% if enable_tls  or enable_wss %}
 # ----- cert managment for tls and wss ----

--- a/templates/opensips.cfg.j2
+++ b/templates/opensips.cfg.j2
@@ -168,9 +168,9 @@ modparam("rtpengine", "rtpengine_sock", "udp:{{ listen_ip }}:60000")
 {% if enable_tls  or enable_wss %}
 # ----- cert managment for tls and wss ----
 modparam("tls_mgm", "certificate",
-         "/etc/letsencrypt/live/mydomain.com/cert.pem")
+         "/etc/letsencrypt/live/{{ domain }}/cert.pem")
 modparam("tls_mgm", "private_key",
-         "/etc/letsencrypt/live/mydomain.com/privkey.pem")
+         "/etc/letsencrypt/live/{{ domain }}/privkey.pem")
 {% endif %}
 
 # branch flags

--- a/templates/rtpengine.sysconfig.j2
+++ b/templates/rtpengine.sysconfig.j2
@@ -1,2 +1,2 @@
 # Add extra options here
-OPTIONS="--interface {{ listen_ip }} --listen-ng {{ listen_ip }}:60000 -m 50000 -M 55000 -E -L 7"
+OPTIONS="--interface {{ listen_ip }} --listen-ng 127.0.0.1:60000 -m 50000 -M 55000 -E -L 7"

--- a/variables.yml.sample
+++ b/variables.yml.sample
@@ -17,6 +17,7 @@ log_facility: LOG_LOCAL2
 db_url: sqlite://var/db/opensips/opensips
 use_enum: 0
 debug_level: 3
+compile_opensips == 'false'
 # We set db_url then reference it for all other db_urls
 # since they share a common db.  You can set them individually.
 group_db_url: "{{ db_url }}"


### PR DESCRIPTION
I'm bad at this, feel free to keep if any of it is useful to you.

- It doesn't include the Debian apt commands, I installed manually. May fix later. This just disables all the yum install lines on non-Redhat like systems so it will actually run.
- If TLS is enabled, the certificate domain location was broken. Fixed with domain variable
- Since the builds of opensips don't include the rtpengine module, I added a switch to compile it with all the modules that are linked in the config file. Dependencies need to be already present.
- rtpengine listen-ng was bound to external device. I don't think that's necessary (it only listens to opensips directly).
